### PR TITLE
Bind PostgreSQL Docker container to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: "timescale/timescaledb:latest-pg13"
     restart: always
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres


### PR DESCRIPTION
PostgreSQL services open to the internet are vulnerable to multiple exploits like the introduction of the Kinsing malware. We recommend keeping the port only accessible via localhost.

More information: https://www.itworldcanada.com/post/kinsing-malware-exploiting-misconfigured-and-exposed-postgresql-servers